### PR TITLE
Make probe universal

### DIFF
--- a/cmd/livenessprobe_test.go
+++ b/cmd/livenessprobe_test.go
@@ -62,7 +62,7 @@ func createMockServer(t *testing.T) (
 }
 
 func TestProbe(t *testing.T) {
-	mockController, driver, idServer, _, nodeServer, csiConn, err := createMockServer(t)
+	mockController, driver, idServer, _, _, csiConn, err := createMockServer(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,19 +70,7 @@ func TestProbe(t *testing.T) {
 	defer driver.Stop()
 	defer csiConn.Close()
 
-	// Setting up expected calls' responses
-	inPlugin := &csi.GetPluginInfoRequest{}
-	outPlugin := &csi.GetPluginInfoResponse{
-		Name: "foo/bar",
-	}
 	var injectedErr error
-	idServer.EXPECT().GetPluginInfo(gomock.Any(), inPlugin).Return(outPlugin, injectedErr).Times(1)
-
-	inNode := &csi.NodeGetIdRequest{}
-	outNode := &csi.NodeGetIdResponse{
-		NodeId: "test_node_id",
-	}
-	nodeServer.EXPECT().NodeGetId(gomock.Any(), inNode).Return(outNode, injectedErr).Times(1)
 	inProbe := &csi.ProbeRequest{}
 	outProbe := &csi.ProbeResponse{}
 	idServer.EXPECT().Probe(gomock.Any(), inProbe).Return(outProbe, injectedErr).Times(1)

--- a/cmd/livenessprobe_test.go
+++ b/cmd/livenessprobe_test.go
@@ -71,6 +71,14 @@ func TestProbe(t *testing.T) {
 	defer csiConn.Close()
 
 	var injectedErr error
+
+	// Setting up expected calls' responses
+	inPlugin := &csi.GetPluginInfoRequest{}
+	outPlugin := &csi.GetPluginInfoResponse{
+		Name: "foo/bar",
+	}
+	idServer.EXPECT().GetPluginInfo(gomock.Any(), inPlugin).Return(outPlugin, injectedErr).Times(1)
+
 	inProbe := &csi.ProbeRequest{}
 	outProbe := &csi.ProbeResponse{}
 	idServer.EXPECT().Probe(gomock.Any(), inProbe).Return(outProbe, injectedErr).Times(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -42,6 +42,13 @@ var (
 )
 
 func runProbe(ctx context.Context, csiConn connection.CSIConnection) error {
+	// Get CSI driver name.
+	glog.Infof("Calling CSI driver to discover driver name.")
+	csiDriverName, err := csiConn.GetDriverName(ctx)
+	if err != nil {
+		return err
+	}
+	glog.Infof("CSI driver name: %q", csiDriverName)
 	// Sending Probe request
 	glog.Infof("Sending probe request to CSI driver.")
 	if err := csiConn.LivenessProbe(ctx); err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -42,23 +42,6 @@ var (
 )
 
 func runProbe(ctx context.Context, csiConn connection.CSIConnection) error {
-
-	// Get CSI driver name.
-	glog.Infof("Calling CSI driver to discover driver name.")
-	csiDriverName, err := csiConn.GetDriverName(ctx)
-	if err != nil {
-		return err
-	}
-	glog.Infof("CSI driver name: %q", csiDriverName)
-
-	// Get CSI Driver Node ID
-	glog.Infof("Calling CSI driver to discover node ID.")
-	csiDriverNodeID, err := csiConn.NodeGetId(ctx)
-	if err != nil {
-		return err
-	}
-	glog.Infof("CSI driver node ID: %q", csiDriverNodeID)
-
 	// Sending Probe request
 	glog.Infof("Sending probe request to CSI driver.")
 	if err := csiConn.LivenessProbe(ctx); err != nil {

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -36,9 +36,6 @@ type CSIConnection interface {
 	// call.
 	GetDriverName(ctx context.Context) (string, error)
 
-	// NodeGetId returns node ID of the current according to the CSI driver.
-	NodeGetId(ctx context.Context) (string, error)
-
 	// Liveness Probe
 	LivenessProbe(ctx context.Context) error
 
@@ -124,22 +121,6 @@ func (c *csiConnection) LivenessProbe(ctx context.Context) error {
 		return err
 	}
 	return nil
-}
-
-func (c *csiConnection) NodeGetId(ctx context.Context) (string, error) {
-	client := csi.NewNodeClient(c.conn)
-
-	req := csi.NodeGetIdRequest{}
-
-	rsp, err := client.NodeGetId(ctx, &req)
-	if err != nil {
-		return "", err
-	}
-	nodeID := rsp.GetNodeId()
-	if nodeID == "" {
-		return "", fmt.Errorf("node ID is empty")
-	}
-	return nodeID, nil
 }
 
 func (c *csiConnection) Close() error {


### PR DESCRIPTION
This PR removes CSI driver specific calls and leaving only Identity Probe call. This change will allow make liveness probe usable for other CSI components, example provisioner or attacher as long as they support Identity Probe calls.
Closes: https://github.com/kubernetes-csi/livenessprobe/issues/17

Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>