### PR TITLE
fix README.md double volumeMounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,6 @@ spec:
  # The liveness probe sidecar container
  - name: liveness-probe
     imagePullPolicy: Always
-    volumeMounts:
-    - mountPath: /csi
-      name: socket-dir
     image: quay.io/k8scsi/livenessprobe:v1.1.0
     args:
     - --csi-address=/csi/csi.sock


### PR DESCRIPTION
README.md is found double volumeMounts yaml config.
it make me confused, I think it should be fixed.
