### PR TITLE
Fix error nil pointer bug when driver not ok but respond

### DIFF
--- a/cmd/livenessprobe/main.go
+++ b/cmd/livenessprobe/main.go
@@ -61,7 +61,6 @@ func (h *healthProbe) checkProbe(w http.ResponseWriter, req *http.Request) {
 
 	if !ready {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(err.Error()))
 		klog.Error("driver responded but is not ready")
 		return
 	}

--- a/cmd/livenessprobe/main.go
+++ b/cmd/livenessprobe/main.go
@@ -61,6 +61,7 @@ func (h *healthProbe) checkProbe(w http.ResponseWriter, req *http.Request) {
 
 	if !ready {
 		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("driver responded but is not ready"))
 		klog.Error("driver responded but is not ready")
 		return
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug


**What this PR does / why we need it**:
 Fix nil pointer error when driver is not ok but respond
 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixes nil pointer bug when driver responds with not ready
```
