### PR TITLE
Open a new connection for each probe call

### DIFF
--- a/cmd/livenessprobe/main.go
+++ b/cmd/livenessprobe/main.go
@@ -34,10 +34,9 @@ import (
 
 // Command line flags
 var (
-	probeTimeout   = flag.Duration("probe-timeout", time.Second, "Probe timeout in seconds")
-	connectTimeout = flag.Duration("connect-timeout", 0, "Limit time to establish a connection to CSI driver")
-	csiAddress     = flag.String("csi-address", "/run/csi/socket", "Address of the CSI driver socket.")
-	healthzPort    = flag.String("health-port", "9808", "TCP ports for listening healthz requests")
+	probeTimeout = flag.Duration("probe-timeout", time.Second, "Probe timeout in seconds")
+	csiAddress   = flag.String("csi-address", "/run/csi/socket", "Address of the CSI driver socket.")
+	healthzPort  = flag.String("health-port", "9808", "TCP ports for listening healthz requests")
 )
 
 type healthProbe struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Instead of sending Probe calls through a single long-lived connection, we create a new one for each gRPC call.

**Which issue(s) this PR fixes**:
Fixes #68 

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
Reports an unhealthy status on `/healthz` endpoint, if the CSI driver socket file does not exist anymore (accidentally removed on the host, for example).
```