### PR TITLE
Add rest of sig-storage chairs and tech-leads to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,3 +2,5 @@ approvers:
 - saad-ali
 - sbezverk
 - msau42
+- jsafrane
+- xing-yang


### PR DESCRIPTION
To have full sig-storage as OWNERS.

/kind cleanup
```release-note
NONE
```
