### PR TITLE
master: update release-tools

### DIFF
--- a/release-tools/SIDECAR_RELEASE_PROCESS.md
+++ b/release-tools/SIDECAR_RELEASE_PROCESS.md
@@ -39,10 +39,11 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
 1. Changes can then be updated in all the sidecar repos and hostpath driver repo
    by following the [update
    instructions](https://github.com/kubernetes-csi/csi-release-tools/blob/master/README.md#sharing-and-updating).
-1. New pull and CI jobs are configured by
+1. New pull and CI jobs are configured by adding new K8s versions to the top of
    [gen-jobs.sh](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-csi/gen-jobs.sh).
-   New pull jobs that have been unverified should be initially made optional.
-   [Example](https://github.com/kubernetes/test-infra/pull/15055)
+   New pull jobs that have been unverified should be initially made optional by
+   setting the new K8s version as
+   [experimental](https://github.com/kubernetes/test-infra/blob/a1858f46d6014480b130789df58b230a49203a64/config/jobs/kubernetes-csi/gen-jobs.sh#L40).
 1. Once new pull and CI jobs have been verified, and the new Kubernetes version
    is released, we can make the optional jobs required, and also remove the
    Kubernetes versions that are no longer supported.
@@ -54,14 +55,19 @@ naming convention `<hostpath-deployment-version>-on-<kubernetes-version>`.
   generator](https://github.com/kubernetes/release/tree/master/cmd/release-notes)
 1. Generate release notes for the release. Replace arguments with the relevant
   information.
+    * Clean up old cached information (also needed if you are generating release
+      notes for multiple repos)
+      ```bash
+      rm -rf /tmp/k8s-repo
+      ```
     * For new minor releases on master:
-        ```
+        ```bash
         GITHUB_TOKEN=<token> release-notes --discover=mergebase-to-latest
         --github-org=kubernetes-csi --github-repo=external-provisioner
         --required-author="" --output out.md
         ```
     * For new patch releases on a release branch:
-        ```
+        ```bash
         GITHUB_TOKEN=<token> release-notes --discover=patch-to-latest --branch=release-1.1
         --github-org=kubernetes-csi --github-repo=external-provisioner
         --required-author="" --output out.md

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -211,6 +211,10 @@ configvar CSI_PROW_DRIVER_INSTALL "install_csi_driver" "name of the shell functi
 # still use that name.
 configvar CSI_PROW_DRIVER_CANARY "${CSI_PROW_HOSTPATH_CANARY}" "driver image override for canary images"
 
+# Image registry to use for canary images.
+# Only valid if CSI_PROW_DRIVER_CANARY == "canary".
+configvar CSI_PROW_DRIVER_CANARY_REGISTRY "gcr.io/k8s-staging-sig-storage" "registry for canary images"
+
 # The E2E testing can come from an arbitrary repo. The expectation is that
 # the repo supports "go test ./test/e2e -args --storage.testdriver" (https://github.com/kubernetes/kubernetes/pull/72836)
 # after setting KUBECONFIG. As a special case, if the repository is Kubernetes,
@@ -693,7 +697,11 @@ install_csi_driver () {
     fi
 
     if [ "${CSI_PROW_DRIVER_CANARY}" != "stable" ]; then
+      if [ "${CSI_PROW_DRIVER_CANARY}" == "canary" ]; then
+        images="$images IMAGE_TAG=${CSI_PROW_DRIVER_CANARY} IMAGE_REGISTRY=${CSI_PROW_DRIVER_CANARY_REGISTRY}"
+      else
         images="$images IMAGE_TAG=${CSI_PROW_DRIVER_CANARY}"
+      fi
     fi
     # Ignore: Double quote to prevent globbing and word splitting.
     # It's intentional here for $images.


### PR DESCRIPTION
Replace "release-tools" with a squashed commit.

Squashed 'release-tools/' changes from c60f382..a0f195c

[a0f195c](https://github.com/kubernetes-csi/csi-release-tools/commit/a0f195c) Merge pull request #106 from msau42/fix-canary
[7100c12](https://github.com/kubernetes-csi/csi-release-tools/commit/7100c12) Only set staging registry when running canary job
[b3c65f9](https://github.com/kubernetes-csi/csi-release-tools/commit/b3c65f9) Merge pull request #99 from msau42/add-release-process
[e53f3e8](https://github.com/kubernetes-csi/csi-release-tools/commit/e53f3e8) Merge pull request #103 from msau42/fix-canary
[d129462](https://github.com/kubernetes-csi/csi-release-tools/commit/d129462) Document new method for adding CI jobs are new K8s versions
[e73c2ce](https://github.com/kubernetes-csi/csi-release-tools/commit/e73c2ce) Use staging registry for canary tests
[2c09846](https://github.com/kubernetes-csi/csi-release-tools/commit/2c09846) Add cleanup instructions to release-notes generation
[60e1cd3](https://github.com/kubernetes-csi/csi-release-tools/commit/60e1cd3) Merge pull request #98 from pohly/kubernetes-1-19-fixes
[0979c09](https://github.com/kubernetes-csi/csi-release-tools/commit/0979c09) prow.sh: fix E2E suite for Kubernetes >= 1.18
[3b4a2f1](https://github.com/kubernetes-csi/csi-release-tools/commit/3b4a2f1) prow.sh: fix installing Go for Kubernetes 1.19.0
[1fbb636](https://github.com/kubernetes-csi/csi-release-tools/commit/1fbb636) Merge pull request #97 from pohly/go-1.15
[82d108a](https://github.com/kubernetes-csi/csi-release-tools/commit/82d108a) switch to Go 1.15
[d8a2530](https://github.com/kubernetes-csi/csi-release-tools/commit/d8a2530) Merge pull request #95 from msau42/add-release-process
[843bddc](https://github.com/kubernetes-csi/csi-release-tools/commit/843bddc) Add steps on promoting release images
[0345a83](https://github.com/kubernetes-csi/csi-release-tools/commit/0345a83) Merge pull request #94 from linux-on-ibm-z/bump-timeout
[1fdf2d5](https://github.com/kubernetes-csi/csi-release-tools/commit/1fdf2d5) cloud build: bump timeout in Prow job
[41ec6d1](https://github.com/kubernetes-csi/csi-release-tools/commit/41ec6d1) Merge pull request #93 from animeshk08/patch-1
[5a54e67](https://github.com/kubernetes-csi/csi-release-tools/commit/5a54e67) filter-junit: Fix gofmt error
[0676fcb](https://github.com/kubernetes-csi/csi-release-tools/commit/0676fcb) Merge pull request #92 from animeshk08/patch-1
[36ea4ff](https://github.com/kubernetes-csi/csi-release-tools/commit/36ea4ff) filter-junit: Fix golint error
[f5a4203](https://github.com/kubernetes-csi/csi-release-tools/commit/f5a4203) Merge pull request #91 from cyb70289/arm64
[43e50d6](https://github.com/kubernetes-csi/csi-release-tools/commit/43e50d6) prow.sh: enable building arm64 image
[0d5bd84](https://github.com/kubernetes-csi/csi-release-tools/commit/0d5bd84) Merge pull request #90 from pohly/k8s-staging-sig-storage
[3df86b7](https://github.com/kubernetes-csi/csi-release-tools/commit/3df86b7) cloud build: k8s-staging-sig-storage
[c5fd961](https://github.com/kubernetes-csi/csi-release-tools/commit/c5fd961) Merge pull request #89 from pohly/cloud-build-binfmt
[db0c2a7](https://github.com/kubernetes-csi/csi-release-tools/commit/db0c2a7) cloud build: initialize support for running commands in Dockerfile
[be902f4](https://github.com/kubernetes-csi/csi-release-tools/commit/be902f4) Merge pull request #88 from pohly/multiarch-windows-fix
[340e082](https://github.com/kubernetes-csi/csi-release-tools/commit/340e082) build.make: optional inclusion of Windows in multiarch images
[5231f05](https://github.com/kubernetes-csi/csi-release-tools/commit/5231f05) build.make: properly declare push-multiarch
[4569f27](https://github.com/kubernetes-csi/csi-release-tools/commit/4569f27) build.make: fix push-multiarch ambiguity
[17dde9e](https://github.com/kubernetes-csi/csi-release-tools/commit/17dde9e) Merge pull request #87 from pohly/cloud-build
[bd41690](https://github.com/kubernetes-csi/csi-release-tools/commit/bd41690) cloud build: initial set of shared files
[9084fec](https://github.com/kubernetes-csi/csi-release-tools/commit/9084fec) Merge pull request #81 from msau42/add-release-process
[6f2322e](https://github.com/kubernetes-csi/csi-release-tools/commit/6f2322e) Update patch release notes generation command
[0fcc3b1](https://github.com/kubernetes-csi/csi-release-tools/commit/0fcc3b1) Merge pull request #78 from ggriffiths/fix_csi_snapshotter_rbac_version_set
[d8c76fe](https://github.com/kubernetes-csi/csi-release-tools/commit/d8c76fe) Support local snapshot RBAC for pull jobs
[c1bdf5b](https://github.com/kubernetes-csi/csi-release-tools/commit/c1bdf5b) Merge pull request #80 from msau42/add-release-process
[ea1f94a](https://github.com/kubernetes-csi/csi-release-tools/commit/ea1f94a) update release tools instructions
[152396e](https://github.com/kubernetes-csi/csi-release-tools/commit/152396e) Merge pull request #77 from ggriffiths/snapshotter201_update
[7edc146](https://github.com/kubernetes-csi/csi-release-tools/commit/7edc146) Update snapshotter to version 2.0.1
[4cf843f](https://github.com/kubernetes-csi/csi-release-tools/commit/4cf843f) Merge pull request #76 from pohly/build-targets
[3863a0f](https://github.com/kubernetes-csi/csi-release-tools/commit/3863a0f) build for multiple platforms only in CI, add s390x
[8322a7d](https://github.com/kubernetes-csi/csi-release-tools/commit/8322a7d) Merge pull request #72 from pohly/hostpath-update
[7c5a89c](https://github.com/kubernetes-csi/csi-release-tools/commit/7c5a89c) prow.sh: use 1.3.0 hostpath driver for testing
[b8587b2](https://github.com/kubernetes-csi/csi-release-tools/commit/b8587b2) Merge pull request #71 from wozniakjan/test-vet
[fdb3218](https://github.com/kubernetes-csi/csi-release-tools/commit/fdb3218) Change 'make test-vet' to call 'go vet'
[d717c8c](https://github.com/kubernetes-csi/csi-release-tools/commit/d717c8c) Merge pull request #69 from pohly/test-driver-config
[a1432bc](https://github.com/kubernetes-csi/csi-release-tools/commit/a1432bc) Merge pull request #70 from pohly/kubelet-feature-gates
[5f74333](https://github.com/kubernetes-csi/csi-release-tools/commit/5f74333) prow.sh: also configure feature gates for kubelet
[84f78b1](https://github.com/kubernetes-csi/csi-release-tools/commit/84f78b1) prow.sh: generic driver installation
[3c34b4f](https://github.com/kubernetes-csi/csi-release-tools/commit/3c34b4f) Merge pull request #67 from windayski/fix-link
[fa90abd](https://github.com/kubernetes-csi/csi-release-tools/commit/fa90abd) fix incorrect link
[ff3cc3f](https://github.com/kubernetes-csi/csi-release-tools/commit/ff3cc3f) Merge pull request #54 from msau42/add-release-process
[ac8a021](https://github.com/kubernetes-csi/csi-release-tools/commit/ac8a021) Document the process for releasing a new sidecar
[23be652](https://github.com/kubernetes-csi/csi-release-tools/commit/23be652) Merge pull request #65 from msau42/update-hostpath
[6582f2f](https://github.com/kubernetes-csi/csi-release-tools/commit/6582f2f) Update hostpath driver version to get fix for connection-timeout
[4cc9174](https://github.com/kubernetes-csi/csi-release-tools/commit/4cc9174) Merge pull request #64 from ggriffiths/snapshotter_2_version_update
[8191eab](https://github.com/kubernetes-csi/csi-release-tools/commit/8191eab) Update snapshotter to version v2.0.0
[3c463fb](https://github.com/kubernetes-csi/csi-release-tools/commit/3c463fb) Merge pull request #61 from msau42/enable-snapshots
[8b0316c](https://github.com/kubernetes-csi/csi-release-tools/commit/8b0316c) Fix overriding of junit results by using unique names for each e2e run
[5f444b8](https://github.com/kubernetes-csi/csi-release-tools/commit/5f444b8) Merge pull request #60 from saad-ali/updateHostpathVersion
[af9549b](https://github.com/kubernetes-csi/csi-release-tools/commit/af9549b) Update prow hostpath driver version to 1.3.0-rc2
[f6c74b3](https://github.com/kubernetes-csi/csi-release-tools/commit/f6c74b3) Merge pull request #57 from ggriffiths/version_gt_kubernetes_fix
[fc80975](https://github.com/kubernetes-csi/csi-release-tools/commit/fc80975) Fix version_gt to work with kubernetes prefix
[9f1f3dd](https://github.com/kubernetes-csi/csi-release-tools/commit/9f1f3dd) Merge pull request #56 from msau42/enable-snapshots
[b98b2ae](https://github.com/kubernetes-csi/csi-release-tools/commit/b98b2ae) Enable snapshot tests in 1.17 to be run in non-alpha jobs.
[9ace020](https://github.com/kubernetes-csi/csi-release-tools/commit/9ace020) Merge pull request #52 from msau42/update-readme
[540599b](https://github.com/kubernetes-csi/csi-release-tools/commit/540599b) Merge pull request #53 from msau42/fix-make
[a4e6299](https://github.com/kubernetes-csi/csi-release-tools/commit/a4e6299) fix syntax for ppc64le build
[771ca6f](https://github.com/kubernetes-csi/csi-release-tools/commit/771ca6f) Merge pull request #49 from ggriffiths/prowsh_improve_version_gt
[d7c69d2](https://github.com/kubernetes-csi/csi-release-tools/commit/d7c69d2) Merge pull request #51 from msau42/enable-multinode
[4ad6949](https://github.com/kubernetes-csi/csi-release-tools/commit/4ad6949) Improve snapshot pod running checks and improve version_gt
[53888ae](https://github.com/kubernetes-csi/csi-release-tools/commit/53888ae) Improve README by adding an explicit Kubernetes dependency section
[9a7a685](https://github.com/kubernetes-csi/csi-release-tools/commit/9a7a685) Create a kind cluster with two worker nodes so that the topology feature can be tested. Test cases that test accessing volumes from multiple nodes need to be skipped
[4ff2f5f](https://github.com/kubernetes-csi/csi-release-tools/commit/4ff2f5f) Merge pull request #50 from darkowlzz/kind-0.6.0
[80bba1f](https://github.com/kubernetes-csi/csi-release-tools/commit/80bba1f) Use kind v0.6.0
[6d674a7](https://github.com/kubernetes-csi/csi-release-tools/commit/6d674a7) Merge pull request #47 from Pensu/multi-arch
[8adde49](https://github.com/kubernetes-csi/csi-release-tools/commit/8adde49) Merge pull request #45 from ggriffiths/snapshot_beta_crds
[003c14b](https://github.com/kubernetes-csi/csi-release-tools/commit/003c14b) Add snapshotter CRDs after cluster setup
[a41f386](https://github.com/kubernetes-csi/csi-release-tools/commit/a41f386) Merge pull request #46 from mucahitkurt/kind-cluster-cleanup
[1eaaaa1](https://github.com/kubernetes-csi/csi-release-tools/commit/1eaaaa1) Delete kind cluster after tests run.
[83a4ef1](https://github.com/kubernetes-csi/csi-release-tools/commit/83a4ef1) Adding build for ppc64le
[4fcafec](https://github.com/kubernetes-csi/csi-release-tools/commit/4fcafec) Merge pull request #43 from pohly/system-pod-logging
[f41c135](https://github.com/kubernetes-csi/csi-release-tools/commit/f41c135) prow.sh: also log output of system containers
[ee22a9c](https://github.com/kubernetes-csi/csi-release-tools/commit/ee22a9c) Merge pull request #42 from pohly/use-vendor-dir
[8067845](https://github.com/kubernetes-csi/csi-release-tools/commit/8067845) travis.yml: also use vendor directory
[23df4ae](https://github.com/kubernetes-csi/csi-release-tools/commit/23df4ae) prow.sh: use vendor directory if available
[a53bd4c](https://github.com/kubernetes-csi/csi-release-tools/commit/a53bd4c) Merge pull request #41 from pohly/go-version
[c8a1c4a](https://github.com/kubernetes-csi/csi-release-tools/commit/c8a1c4a) better handling of Go version
[5e773d2](https://github.com/kubernetes-csi/csi-release-tools/commit/5e773d2) update CI to use Go 1.13.3
[f419d74](https://github.com/kubernetes-csi/csi-release-tools/commit/f419d74) Merge pull request #40 from msau42/add-1.16
[e0fde8c](https://github.com/kubernetes-csi/csi-release-tools/commit/e0fde8c) Add new variables for 1.16 and remove 1.13
[adf00fe](https://github.com/kubernetes-csi/csi-release-tools/commit/adf00fe) Merge pull request #36 from msau42/full-clone
[f1697d2](https://github.com/kubernetes-csi/csi-release-tools/commit/f1697d2) Do full git clones in travis. Shallow clones are causing test-subtree errors when the depth is exactly 50.
[2c81919](https://github.com/kubernetes-csi/csi-release-tools/commit/2c81919) Merge pull request #34 from pohly/go-mod-tidy
[518d6af](https://github.com/kubernetes-csi/csi-release-tools/commit/518d6af) Merge pull request #35 from ddebroy/winbld2
[2d6b3ce](https://github.com/kubernetes-csi/csi-release-tools/commit/2d6b3ce) Build Windows only for amd64
[c1078a6](https://github.com/kubernetes-csi/csi-release-tools/commit/c1078a6) go-get-kubernetes.sh: automate Kubernetes dependency handling
[194289a](https://github.com/kubernetes-csi/csi-release-tools/commit/194289a) update Go mod support
[0affdf9](https://github.com/kubernetes-csi/csi-release-tools/commit/0affdf9) Merge pull request #33 from gnufied/enable-hostpath-expansion
[6208f6a](https://github.com/kubernetes-csi/csi-release-tools/commit/6208f6a) Enable hostpath expansion
[6ecaa76](https://github.com/kubernetes-csi/csi-release-tools/commit/6ecaa76) Merge pull request #30 from msau42/fix-windows
[ea2f1b5](https://github.com/kubernetes-csi/csi-release-tools/commit/ea2f1b5) build windows binaries with .exe suffix
[2d33550](https://github.com/kubernetes-csi/csi-release-tools/commit/2d33550) Merge pull request #29 from mucahitkurt/create-2-node-kind-cluster
[a8ea8bc](https://github.com/kubernetes-csi/csi-release-tools/commit/a8ea8bc) create 2-node kind cluster since topology support is added to hostpath driver
[df8530d](https://github.com/kubernetes-csi/csi-release-tools/commit/df8530d) Merge pull request #27 from pohly/dep-vendor-check
[35ceaed](https://github.com/kubernetes-csi/csi-release-tools/commit/35ceaed) prow.sh: install dep if needed
[f85ab5a](https://github.com/kubernetes-csi/csi-release-tools/commit/f85ab5a) Merge pull request #26 from ddebroy/windows1
[9fba09b](https://github.com/kubernetes-csi/csi-release-tools/commit/9fba09b) Add rule for building Windows binaries
[0400867](https://github.com/kubernetes-csi/csi-release-tools/commit/0400867) Merge pull request #25 from msau42/fix-master-jobs
[dc0a5d8](https://github.com/kubernetes-csi/csi-release-tools/commit/dc0a5d8) Update kind to v0.5.0
[aa85b82](https://github.com/kubernetes-csi/csi-release-tools/commit/aa85b82) Merge pull request #23 from msau42/fix-master-jobs
[f46191d](https://github.com/kubernetes-csi/csi-release-tools/commit/f46191d) Kubernetes master changed the way that releases are tagged, which needed changes to kind. There are 3 changes made to prow.sh:
[1cac3af](https://github.com/kubernetes-csi/csi-release-tools/commit/1cac3af) Merge pull request #22 from msau42/add-1.15-jobs
[0c0dc30](https://github.com/kubernetes-csi/csi-release-tools/commit/0c0dc30) prow.sh: tag master images with a large version number
[f4f73ce](https://github.com/kubernetes-csi/csi-release-tools/commit/f4f73ce) Merge pull request #21 from msau42/add-1.15-jobs
[4e31f07](https://github.com/kubernetes-csi/csi-release-tools/commit/4e31f07) Change default hostpath driver name to hostpath.csi.k8s.io
[4b6fa4a](https://github.com/kubernetes-csi/csi-release-tools/commit/4b6fa4a) Update hostpath version for sidecar testing to v1.2.0-rc2
[ecc7918](https://github.com/kubernetes-csi/csi-release-tools/commit/ecc7918) Update kind to v0.4.0. This requires overriding Kubernetes versions with specific patch versions that kind 0.4.0 supports. Also, feature gate setting is only supported on 1.15+ due to kind.sigs.k8s.io/v1alpha3 and kubeadm.k8s.io/v1beta2 dependencies.
[a6f21d4](https://github.com/kubernetes-csi/csi-release-tools/commit/a6f21d4) Add variables for 1.15
[db8abb6](https://github.com/kubernetes-csi/csi-release-tools/commit/db8abb6) Merge pull request #20 from pohly/test-driver-config
[b2f4e05](https://github.com/kubernetes-csi/csi-release-tools/commit/b2f4e05) prow.sh: flexible test driver config
[0399988](https://github.com/kubernetes-csi/csi-release-tools/commit/0399988) Merge pull request #19 from pohly/go-mod-vendor
[066143d](https://github.com/kubernetes-csi/csi-release-tools/commit/066143d) build.make: allow repos to use 'go mod' for vendoring
[0bee749](https://github.com/kubernetes-csi/csi-release-tools/commit/0bee749) Merge pull request #18 from pohly/go-version
[e157b6b](https://github.com/kubernetes-csi/csi-release-tools/commit/e157b6b) update to Go 1.12.4
[88dc9a4](https://github.com/kubernetes-csi/csi-release-tools/commit/88dc9a4) Merge pull request #17 from pohly/prow
[0fafc66](https://github.com/kubernetes-csi/csi-release-tools/commit/0fafc66) prow.sh: skip sanity testing if component doesn't support it
[bcac1c1](https://github.com/kubernetes-csi/csi-release-tools/commit/bcac1c1) Merge pull request #16 from pohly/prow
[0b10f6a](https://github.com/kubernetes-csi/csi-release-tools/commit/0b10f6a) prow.sh: update csi-driver-host-path
[0c2677e](https://github.com/kubernetes-csi/csi-release-tools/commit/0c2677e) Merge pull request #15 from pengzhisun/master
[ff9bce4](https://github.com/kubernetes-csi/csi-release-tools/commit/ff9bce4) Replace 'return' to 'exit' to fix shellcheck error

git-subtree-dir: release-tools
git-subtree-split: a0f195cc2ddc2a1f07d4d3e46fc08187db358f94

```release-note
NONE
```