### PR TITLE
Revert to multiarch distroless base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/distroless/static:latest-amd64
+FROM gcr.io/distroless/static:latest
 LABEL maintainers="Kubernetes Authors"
 LABEL description="CSI Driver liveness probe"
 ARG binary=./bin/livenessprobe


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: Support for s390x/ppc64le has been added to distroless static/base images and hence the Dockerfiles can go back to using multiarch images.

**Which issue(s) this PR fixes**:

Fixes # https://github.com/kubernetes-csi/csi-release-tools/issues/105

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note

Changing distroless image back to multiarch
```