### PR TITLE
master: update release-tools

### DIFF
--- a/release-tools/build.make
+++ b/release-tools/build.make
@@ -69,12 +69,17 @@ endif
 # toolchain.
 BUILD_PLATFORMS =
 
+# Add go ldflags using LDFLAGS at the time of compilation.
+IMPORTPATH_LDFLAGS = -X main.version=$(REV) 
+EXT_LDFLAGS = -extldflags "-static"
+LDFLAGS = 
+FULL_LDFLAGS = $(LDFLAGS) $(IMPORTPATH_LDFLAGS) $(EXT_LDFLAGS)
 # This builds each command (= the sub-directories of ./cmd) for the target platform(s)
 # defined by BUILD_PLATFORMS.
 $(CMDS:%=build-%): build-%: check-go-version-go
 	mkdir -p bin
 	echo '$(BUILD_PLATFORMS)' | tr ';' '\n' | while read -r os arch suffix; do \
-		if ! (set -x; CGO_ENABLED=0 GOOS="$$os" GOARCH="$$arch" go build $(GOFLAGS_VENDOR) -a -ldflags '-X main.version=$(REV) -extldflags "-static"' -o "./bin/$*$$suffix" ./cmd/$*); then \
+		if ! (set -x; CGO_ENABLED=0 GOOS="$$os" GOARCH="$$arch" go build $(GOFLAGS_VENDOR) -a -ldflags '$(FULL_LDFLAGS)' -o "./bin/$*$$suffix" ./cmd/$*); then \
 			echo "Building $* for GOOS=$$os GOARCH=$$arch failed, see error(s) above."; \
 			exit 1; \
 		fi; \


### PR DESCRIPTION
Squashed 'release-tools/' changes from a0f195c..4aff857

[4aff857](https://github.com/kubernetes-csi/csi-release-tools/commit/4aff857) Merge pull request #109 from pohly/alpha-test-defaults
[0427289](https://github.com/kubernetes-csi/csi-release-tools/commit/0427289) Merge pull request #110 from pohly/kind-0.9-bazel-build-workaround
[9a370ab](https://github.com/kubernetes-csi/csi-release-tools/commit/9a370ab) prow.sh: work around "kind build node-image" failure
[522361e](https://github.com/kubernetes-csi/csi-release-tools/commit/522361e) prow.sh: only run alpha tests for latest Kubernetes release
[22c0395](https://github.com/kubernetes-csi/csi-release-tools/commit/22c0395) Merge pull request #108 from bnrjee/master
[b5b447b](https://github.com/kubernetes-csi/csi-release-tools/commit/b5b447b) Add go ldflags using LDFLAGS at the time of compilation
[16f4afb](https://github.com/kubernetes-csi/csi-release-tools/commit/16f4afb) Merge pull request #107 from pohly/kind-update
[7bcee13](https://github.com/kubernetes-csi/csi-release-tools/commit/7bcee13) prow.sh: update to kind 0.9, support Kubernetes 1.19
[df518fb](https://github.com/kubernetes-csi/csi-release-tools/commit/df518fb) prow.sh: usage of Bazel optional
[c3afd42](https://github.com/kubernetes-csi/csi-release-tools/commit/c3afd42) Merge pull request #104 from xing-yang/snapshot
[dde93b2](https://github.com/kubernetes-csi/csi-release-tools/commit/dde93b2) Update to snapshot-controller v3.0.0

git-subtree-dir: release-tools
git-subtree-split: 4aff857d88149e07951fcd1322f462f765401a86

```release-note
NONE
```