### PR TITLE
Make livenessprobe logging a little less verbose

### DIFF
--- a/deployment/kubernetes/livenessprobe-sidecar.yaml
+++ b/deployment/kubernetes/livenessprobe-sidecar.yaml
@@ -49,6 +49,6 @@
       name: socket-dir
     image: quay.io/k8scsi/livenessprobe:canary
     args:
-    - --v=5
+    - --v=4
     - --csi-address=/csi/csi.sock
 #


### PR DESCRIPTION
The livenessprobe sidecar seems to produce a disproportionate number
of logging messages. On our system it can, at times, produce about 60% of all
kubernetes related log messages (about 4 million of 6 million messages
over a 24 hour period).

Reduce the default from '5' to '4'. This will remove the 'most verbose' level
messages and reduce load on the logging infrastructure.

/kind cleanup

```release-note
Default log level of livenessprobe-sidecar reduced to '4'. 
```
