### PR TITLE
Introducing http-endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,17 @@ spec:
 
 #### Other recognized arguments
 
-* `--health-port <number>`: TCP ports for listening for HTTP requests (default "9808")
-
 * `--probe-timeout <duration>`: Maximum duration of single `Probe()` call (default "1s").
 
-* `--metrics-address <port>`: The TCP network address where the prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means metrics endpoint is disabled.
+* `--http-endpoint <port>`: The TCP network address where the HTTP server for diagnostics, including CSI driver health check and metrics, will listen (example: `:8080`). The default is `:9808`.
 
 * `--metrics-path <path>`: The HTTP path where prometheus metrics will be exposed. Default is `/metrics`."
+
+* `--health-port <number>`: TCP ports for listening for HTTP requests (default "9808")
+  * Removed in version 3.0.0, where the flag is replaced by `--http-endpoint`.
+
+* `--metrics-address <port>`: The TCP network address where the prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means metrics endpoint is disabled.
+  * Removed in version 3.0.0, where the flag is replaced by `--http-endpoint` and is always enabled.
 
 * All glog / klog arguments are supported, such as `-v <log level>` or `-alsologtostderr`.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: Replacement of https://github.com/kubernetes-csi/livenessprobe/pull/95. Replaces `metrics-address` and `health-port` flags with `http-endpoint`.

**Special notes for your reviewer**: Requires a major version bump.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
`--metrics-address` and `--health-port` flags are combined into a single flag, `http-endpoint.` The metrics server is also now always enabled.
```

/assign @Jiawei0227 @msau42 