### PR TITLE
Introducing http-endpoint

### DIFF
--- a/cmd/livenessprobe/main.go
+++ b/cmd/livenessprobe/main.go
@@ -19,8 +19,10 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
@@ -32,12 +34,17 @@ import (
 	"github.com/kubernetes-csi/csi-lib-utils/rpc"
 )
 
+const (
+	defaultHealthzPort = "9808"
+)
+
 // Command line flags
 var (
-	probeTimeout   = flag.Duration("probe-timeout", time.Second, "Probe timeout in seconds")
+	probeTimeout   = flag.Duration("probe-timeout", time.Second, "Probe timeout in seconds.")
 	csiAddress     = flag.String("csi-address", "/run/csi/socket", "Address of the CSI driver socket.")
-	healthzPort    = flag.String("health-port", "9808", "TCP ports for listening healthz requests")
-	metricsAddress = flag.String("metrics-address", "", "The TCP network address where the prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means metrics endpoint is disabled.")
+	healthzPort    = flag.String("health-port", defaultHealthzPort, fmt.Sprintf("(deprecated) TCP ports for listening healthz requests. The default is `%s`. If set, `--http-endpoint` cannot be set.", defaultHealthzPort))
+	metricsAddress = flag.String("metrics-address", "", "(deprecated) The TCP network address where the prometheus metrics endpoint will listen (example: `:8080`). The default is empty string, which means metrics endpoint is disabled. If set, `--http-endpoint` cannot be set, and the address cannot resolve to localhost + the port from `--health-port`.")
+	httpEndpoint   = flag.String("http-endpoint", "", "The TCP network address where the HTTP server for diagnostics, including CSI driver health check and metrics. The default is empty string, which means the server is disabled. If set, `--health-port` and `--metrics-address` cannot be explicitly set.")
 	metricsPath    = flag.String("metrics-path", "/metrics", "The HTTP path where prometheus metrics will be exposed. Default is `/metrics`.")
 )
 
@@ -115,6 +122,22 @@ func main() {
 	klog.InitFlags(nil)
 	flag.Set("logtostderr", "true")
 	flag.Parse()
+
+	if *healthzPort != defaultHealthzPort && *httpEndpoint != "" {
+		klog.Error("only one of `--health-port` and `--http-endpoint` can be explicitly set.")
+		os.Exit(1)
+	}
+	if *metricsAddress != "" && *httpEndpoint != "" {
+		klog.Error("only one of `--metrics-address` and `--http-endpoint` can be explicitly set.")
+		os.Exit(1)
+	}
+	var addr string
+	if *httpEndpoint != "" {
+		addr = *httpEndpoint
+	} else {
+		addr = net.JoinHostPort("0.0.0.0", *healthzPort)
+	}
+
 	metricsManager := metrics.NewCSIMetricsManager("" /* driverName */)
 	csiConn, err := acquireConnection(context.Background(), metricsManager)
 	if err != nil {
@@ -137,12 +160,27 @@ func main() {
 	}
 
 	mux := http.NewServeMux()
-	addr := net.JoinHostPort("0.0.0.0", *healthzPort)
-	metricsManager.RegisterToServer(mux, *metricsPath)
 	metricsManager.SetDriverName(csiDriverName)
 
+	if *metricsAddress == "" {
+		if *httpEndpoint != "" {
+			metricsManager.RegisterToServer(mux, *metricsPath)
+		}
+	} else {
+		// Remove once --metrics-address is removed
+		metricsMux := http.NewServeMux()
+		metricsManager.RegisterToServer(metricsMux, *metricsPath)
+		go func() {
+			klog.Infof("Separate metrics ServeMux listening at %q", *metricsAddress)
+			err := http.ListenAndServe(*metricsAddress, metricsMux)
+			if err != nil {
+				klog.Fatalf("Failed to start prometheus metrics endpoint on specified address (%q) and path (%q): %s", *metricsAddress, *metricsPath, err)
+			}
+		}()
+	}
+
 	mux.HandleFunc("/healthz", hp.checkProbe)
-	klog.Infof("Serving requests to /healthz on: %s", addr)
+	klog.Infof("ServeMux listening at %q", addr)
 	err = http.ListenAndServe(addr, mux)
 	if err != nil {
 		klog.Fatalf("failed to start http server with error: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: Variation of https://github.com/kubernetes-csi/livenessprobe/pull/95. Here `http-endpoint` has no default. http-endpoint can't be set when metrics-address or health-port are set, and vice versa. When none of these flags are set, the default `health-port` is used, in which case /metrics is disabled.

Making old and new flags mutually exclusive makes the intention of deprecation more clear.

**Special notes for your reviewer**:

| health | metric | http | Behavior |
| - | - | - | - |
| unset | unset | unset | /healthz at default address |
| unset | unset | set | /metrics and /healthz at set address |
| unset | set | unset | /metrics at set address, /healthz at default address |
| unset | set | set | error |
| set | unset | unset | /healthz at set address |
| set | unset | set | error |
| set | set | unset | /metrics at set address, /healthz at set port |
| set | set | set | error |

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
ACTION REQUIRED: `--metrics-address` and `--health-port` flags are combined into a single flag, `http-endpoint.`
```
