### PR TITLE
Multi windows-distro docker build args

### DIFF
--- a/Dockerfile.Windows
+++ b/Dockerfile.Windows
@@ -1,12 +1,28 @@
-ARG BASE_IMAGE=servercore
-ARG BASE_IMAGE_TAG=1809
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# These arguments come from BUILD_PLATFORMS used in release-tools
+ARG ADDON_IMAGE=servercore:1809
+ARG BASE_IMAGE=nanoserver:1809
 ARG REGISTRY=mcr.microsoft.com/windows
 
-FROM ${REGISTRY}/${BASE_IMAGE}:${BASE_IMAGE_TAG} as core
-FROM mcr.microsoft.com/windows/nanoserver:${BASE_IMAGE_TAG}
+FROM ${REGISTRY}/${ADDON_IMAGE} as addon
+FROM ${REGISTRY}/${BASE_IMAGE}
 LABEL description="CSI Liveness Probe"
 
 COPY ./bin/livenessprobe.exe /livenessprobe.exe
-COPY --from=core /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll
+COPY --from=addon /Windows/System32/netapi32.dll /Windows/System32/netapi32.dll
+
 USER ContainerAdministrator
 ENTRYPOINT ["/livenessprobe.exe"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind feature

**What this PR does / why we need it**:

Updates the Dockerfile.Windows file to support multi distro windows builds (similar to https://github.com/kubernetes-csi/node-driver-registrar/pull/146), one step closer to provide multi distro images for #106

Next steps: use these arguments in our internal pipelines

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added Dockerfile.Windows build args ADDON_IMAGE and BASE_IMAGE to support multi distro builds
```
