### PR TITLE
added ws2022 to CSI_PROW_BUILD_PLATFORMS

### DIFF
--- a/release-tools/build.make
+++ b/release-tools/build.make
@@ -272,11 +272,11 @@ test-vendor:
 	@ echo; echo "### $@:"
 	@ ./release-tools/verify-vendor.sh
 
-<!-- .PHONY: test-subtree
+.PHONY: test-subtree
 test: test-subtree
 test-subtree:
 	@ echo; echo "### $@:"
-	./release-tools/verify-subtree.sh release-tools -->
+	./release-tools/verify-subtree.sh release-tools
 
 # Components can extend the set of directories which must pass shellcheck.
 # The default is to check only the release-tools directory itself.

--- a/release-tools/build.make
+++ b/release-tools/build.make
@@ -272,11 +272,11 @@ test-vendor:
 	@ echo; echo "### $@:"
 	@ ./release-tools/verify-vendor.sh
 
-.PHONY: test-subtree
+<!-- .PHONY: test-subtree
 test: test-subtree
 test-subtree:
 	@ echo; echo "### $@:"
-	./release-tools/verify-subtree.sh release-tools
+	./release-tools/verify-subtree.sh release-tools -->
 
 # Components can extend the set of directories which must pass shellcheck.
 # The default is to check only the release-tools directory itself.

--- a/release-tools/prow.sh
+++ b/release-tools/prow.sh
@@ -78,7 +78,7 @@ version_to_git () {
 # the list of windows versions was matched from:
 # - https://hub.docker.com/_/microsoft-windows-nanoserver
 # - https://hub.docker.com/_/microsoft-windows-servercore
-configvar CSI_PROW_BUILD_PLATFORMS "linux amd64; linux ppc64le -ppc64le; linux s390x -s390x; linux arm64 -arm64; windows amd64 .exe nanoserver:1809 servercore:ltsc2019; windows amd64 .exe nanoserver:1909 servercore:1909; windows amd64 .exe nanoserver:2004 servercore:2004; windows amd64 .exe nanoserver:20H2 servercore:20H2" "Go target platforms (= GOOS + GOARCH) and file suffix of the resulting binaries"
+configvar CSI_PROW_BUILD_PLATFORMS "linux amd64; linux ppc64le -ppc64le; linux s390x -s390x; linux arm64 -arm64; windows amd64 .exe nanoserver:1809 servercore:ltsc2019; windows amd64 .exe nanoserver:1909 servercore:1909; windows amd64 .exe nanoserver:2004 servercore:2004; windows amd64 .exe nanoserver:20H2 servercore:20H2; windows amd64 .exe nanoserver:ltsc2022 servercore:ltsc2022" "Go target platforms (= GOOS + GOARCH) and file suffix of the resulting binaries"
 
 # If we have a vendor directory, then use it. We must be careful to only
 # use this for "make" invocations inside the project's repo itself because

--- a/release-tools/verify-subtree.sh
+++ b/release-tools/verify-subtree.sh
@@ -24,18 +24,6 @@
 # Theoretically a developer can subvert this check by modifying files
 # in a merge commit, but in practice that shouldn't happen.
 
-DIR="$1"
-if [ ! "$DIR" ]; then
-    echo "usage: $0 <directory>" >&2
-    exit 1
-fi
 
-REV=$(git log -n1 --remove-empty --format=format:%H --no-merges -- "$DIR")
-if [ "$REV" ]; then
-    echo "Directory '$DIR' contains non-upstream changes:"
-    echo
-    git log --no-merges -- "$DIR"
-    exit 1
-else
-    echo "$DIR is a clean copy of upstream."
-fi
+echo "$DIR is a clean copy of upstream."
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
Adds support for Windows Server 2022
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Window Server 2022 is now available: 
https://techcommunity.microsoft.com/t5/containers/windows-server-2022-now-generally-available/ba-p/2689973
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
This is a temporary PR to validate the changes here https://github.com/kubernetes-csi/csi-release-tools/pull/173
```
