### PR TITLE
Don't close nil connection

### DIFF
--- a/cmd/livenessprobe/main.go
+++ b/cmd/livenessprobe/main.go
@@ -99,7 +99,7 @@ func acquireConnection(ctx context.Context, metricsManager metrics.CSIMetricsMan
 
 		m.Lock()
 		defer m.Unlock()
-		if err != nil && canceled {
+		if err != nil && canceled && conn != nil {
 			conn.Close()
 		}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When connlib.Connect returns an error, make sure acquireConnection does not accidentally tries to close a nil conn.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #176

**Special notes for your reviewer**:
In theory this could fix #176. I haven't found an easy way how to make `connlib.Connect` to return error.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed panic on connection failure.
```
