### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/cmd/livenessprobe/livenessprobe_test.go
+++ b/cmd/livenessprobe/livenessprobe_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -53,13 +52,10 @@ func createMockServer(t *testing.T) (
 		Node:       nodeServer,
 	})
 
-	tmpDir, err := ioutil.TempDir("", "livenessprobe_test.*")
-	if err != nil {
-		t.Errorf("failed to create a temporary socket file name: %v", err)
-	}
+	tmpDir := t.TempDir()
 
 	csiEndpoint := fmt.Sprintf("%s/csi.sock", tmpDir)
-	err = drv.StartOnAddress("unix", csiEndpoint)
+	err := drv.StartOnAddress("unix", csiEndpoint)
 	if err != nil {
 		t.Errorf("failed to start the csi driver at %s: %v", csiEndpoint, err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind cleanup


**What this PR does / why we need it**:
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
