### PR TITLE
Prevent a crash loop caused by upstream changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/kubernetes-csi/csi-lib-utils v0.16.0
 	github.com/kubernetes-csi/csi-test/v5 v5.2.0
-	google.golang.org/grpc v1.60.1
 	k8s.io/component-base v0.29.0
 	k8s.io/klog/v2 v2.110.1
 )


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

See https://github.com/kubernetes-csi/livenessprobe/issues/236 and https://github.com/longhorn/longhorn/issues/7116 for a complete analysis.

Now that csi-lib-utils.Connect returns after a configurable 30 second timeout:

- We need to ensure livenessprobe and its CSI plugin don't enter an unrecoverable alternating crash loop that prevents liveness probes from ever succeeding. We do this by setting the connection timeout during initialization to five minutes.
- We can do away with the acquireConnection wrapper function, which previously implemented timeouts at the livenessprobe layer. These timeouts can now simply be passed to the csi-lib-utils layer.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes-csi/livenessprobe/issues/236

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
