### PR TITLE
Parse go version from release-tools

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,29 +1,39 @@
-name: Run Trivy scanner for Go version vulnerabilities
+name: Trivy vulnerability scanner
 on:
   push:
     branches:
       - master
   pull_request:
 jobs:
-  trivy:
+  build:
     name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Get Go version
-        id: go-version
+      - name: Parse go version from release-tools/prow.sh
         run: |
           GO_VERSION=$(cat release-tools/prow.sh  | grep "configvar CSI_PROW_GO_VERSION_BUILD" | awk '{print $3}' | sed 's/"//g')
-          echo "version=$GO_VERSION" >> $GITHUB_OUTPUT
+          echo "Using go from release-tools: $GO_VERSION"
+          echo "$GO_VERSION" >> '.go-version'
 
-      - name: Run Trivy scanner for Go version vulnerabilities
+      - name: Install go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: .go-version
+
+      - name: Build an image from Dockerfile
+        run: |
+          make
+          docker build -t test/livenessprobe:latest -f Dockerfile --output=type=docker --label revision=latest .
+
+      - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: 'golang:${{ steps.go-version.outputs.version }}'
+          image-ref: 'test/livenessprobe:latest'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true
-          vuln-type: 'library'
+          vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
trivy.yaml should use the same go version as release tools, so it checks for CVEs with the same go as we use to build images.

Add a step that parses the go version from `prow.sh` and stores it in `.go-version` file. Use the file in subsequent setup-go step.

This partially reverts https://github.com/kubernetes-csi/livenessprobe/pull/390 and reworks trivy.yaml in a different way.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
