### PR TITLE
Support added for architecture riscv64 (linux)

### DIFF
--- a/.prow.sh
+++ b/.prow.sh
@@ -1,5 +1,8 @@
 #! /bin/bash
 
+# Override CSI_PROW_BUILD_PLATFORMS so we can provide riscv64 support
+CSI_PROW_BUILD_PLATFORMS="linux amd64 amd64; linux ppc64le ppc64le -ppc64le; linux s390x s390x -s390x; linux arm arm -arm; linux arm64 arm64 -arm64; linux arm arm/v7 -armv7; linux riscv64 riscv64 -riscv64; windows amd64 amd64 .exe nanoserver:1809 servercore:ltsc2019; windows amd64 amd64 .exe nanoserver:ltsc2022 servercore:ltsc2022"
+
 . release-tools/prow.sh
 
 main


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:

Now that riscv64 support is available for the distroless Docker image, it's possible to add support for riscv64.

See pull request: GoogleContainerTools/distroless#2001

I tested this combination with my riscv64 Kubernetes cluster (k0s with smb-provider). See: https://www.youtube.com/watch?v=WERPNNyzqqs

Riscv64 support can now be slowly added to Docker images that relied on "gcr.io/distroless/static:latest".

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Support added for architecture riscv64 (linux)
```
